### PR TITLE
fix: remove unsupported split function

### DIFF
--- a/includes/ims-blti/OAuth.php
+++ b/includes/ims-blti/OAuth.php
@@ -836,7 +836,7 @@ class OAuthUtil
 
         $parsed_parameters = [];
         foreach ($pairs as $pair) {
-            $split = preg_split('/=/', $pair, 2);
+            $split = explode('=', $pair, 2);
             $parameter = OAuthUtil::urldecode_rfc3986($split[0]);
             $value = isset($split[1]) ? OAuthUtil::urldecode_rfc3986($split[1]) : '';
 

--- a/includes/ims-blti/OAuth.php
+++ b/includes/ims-blti/OAuth.php
@@ -299,7 +299,7 @@ class OAuthRequest
             $qparms = OAuthUtil::parse_parameters($parts['query']);
             $parameters = array_merge($qparms, $parameters);
         }
-     
+
 
         return new OAuthRequest($http_method, $http_url, $parameters);
     }
@@ -832,11 +832,11 @@ class OAuthUtil
             return [];
         }
 
-        $pairs = split('&', $input);
+        $pairs = preg_split('/&/', $input);
 
         $parsed_parameters = [];
         foreach ($pairs as $pair) {
-            $split = split('=', $pair, 2);
+            $split = preg_split('/=/', $pair, 2);
             $parameter = OAuthUtil::urldecode_rfc3986($split[0]);
             $value = isset($split[1]) ? OAuthUtil::urldecode_rfc3986($split[1]) : '';
 

--- a/includes/ims-blti/OAuth.php
+++ b/includes/ims-blti/OAuth.php
@@ -832,7 +832,7 @@ class OAuthUtil
             return [];
         }
 
-        $pairs = preg_split('/&/', $input);
+        $pairs = explode('&', $input);
 
         $parsed_parameters = [];
         foreach ($pairs as $pair) {

--- a/includes/ims-blti/blti.php
+++ b/includes/ims-blti/blti.php
@@ -80,16 +80,16 @@ class BLTI
             $sql = 'SELECT * FROM ' . $parm['table'] . ' WHERE ' .
                 ($parm['key_column'] ? $parm['key_column'] : 'oauth_consumer_key') .
                 '=' .
-                "'" . mysql_real_escape_string($oauth_consumer_key) . "'";
-            $result = mysql_query($sql);
-            $num_rows = mysql_num_rows($result);
+                "'" . mysqli_real_escape_string($oauth_consumer_key) . "'";
+            $result = mysqli_query($sql);
+            $num_rows = mysqli_num_rows($result);
             if ($num_rows != 1) {
                 $this->message = "Your consumer is not authorized oauth_consumer_key=" . $oauth_consumer_key;
                 return;
             } else {
-                while ($row = mysql_fetch_assoc($result)) {
-                    $secret = $row[$parms['secret_column'] ? $parms['secret_column'] : 'secret'];
-                    $context_id = $row[$parms['context_column'] ? $parms['context_column'] : 'context_id'];
+                while ($row = mysqli_fetch_assoc($result)) {
+                    $secret = $row[$parm['secret_column'] ? $parm['secret_column'] : 'secret'];
+                    $context_id = $row[$parm['context_column'] ? $parm['context_column'] : 'context_id'];
                     if ($context_id) {
                         $this->context_id = $context_id;
                     }
@@ -112,7 +112,7 @@ class BLTI
         $method = new OAuthSignatureMethod_HMAC_SHA1();
         $server->add_signature_method($method);
         $request = OAuthRequest::from_request();
-        
+
         $this->basestring = $request->get_signature_base_string();
 
         try {
@@ -215,7 +215,7 @@ class BLTI
         }
         return $this->getUserName();
     }
-  
+
     function getUserName()
     {
         $givenname = $this->info['lis_person_name_given'];


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1097
https://oat-sa.atlassian.net/browse/ADF-1087
https://oat-sa.atlassian.net/browse/ADF-1105

## Goal 

Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.